### PR TITLE
tmp/facebook redirect fix

### DIFF
--- a/src/UKMNorge/UserBundle/Controller/UKMSecurityController.php
+++ b/src/UKMNorge/UserBundle/Controller/UKMSecurityController.php
@@ -164,7 +164,7 @@ class UKMSecurityController extends BaseController {
             // Brukeren har ikke blitt sendt tilbake via facebook
             $this->addFlash('danger', "Facebook-innloggingen feilet - prøv igjen, eller kontakt UKM Support");
             $this->get('logger')->error("UKMSecurityController::fbloginAction: Facebook-innlogging forsøkt uten å gå via facebook - sannsynligvis bare en bot, men sjekk referrer uansett.", array(
-                    'referrer' => $_SERVER['HTTP_REFERER'],
+                    'referrer' => isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : 'Ikke definert',
                     'redirect_uri' => $redirectURL
                 ));
             return $this->redirectToRoute('ukm_user_login');

--- a/src/UKMNorge/UserBundle/Controller/UKMSecurityController.php
+++ b/src/UKMNorge/UserBundle/Controller/UKMSecurityController.php
@@ -160,6 +160,15 @@ class UKMSecurityController extends BaseController {
         }
 
         $code = $req->query->get('code');
+        if ( null == $code ) {
+            // Brukeren har ikke blitt sendt tilbake via facebook
+            $this->addFlash('danger', "Facebook-innloggingen feilet - prøv igjen, eller kontakt UKM Support");
+            $this->get('logger')->error("UKMSecurityController::fbloginAction: Facebook-innlogging forsøkt uten å gå via facebook - sannsynligvis bare en bot, men sjekk referrer uansett.", array(
+                    'referrer' => $_SERVER['HTTP_REFERER'],
+                    'redirect_uri' => $redirectURL
+                ));
+            return $this->redirectToRoute('ukm_user_login');
+        }
         // Code is received, which means that the user logged in successfully to facebook.
         // Bytt code for en access-token
         $curl = new UKMCurl();


### PR DESCRIPTION
En kjapp kikk på loggene viste at feil-sjekken på [UKMSecurityController#L174](https://github.com/UKMNorge/UKMdelta/blob/master/src/UKMNorge/UserBundle/Controller/UKMSecurityController.php#L174) allerede har slått til med `code = null`.

Dette er mest sannsynlig en crawler som har åpnet `/fblogin` direkte, men vi legger til logging der vi sporer `$_SERVER['HTTP_REFERER']` for å kunne sjekke dette uansett. Dersom noen kommer fra en UKM-side hit bør det gjøres noe med referer-siden.