### PR TITLE
Fix #239 - tilbakemeldinger på oversiktsside

### DIFF
--- a/src/UKMNorge/DeltaBundle/Controller/InnslagController.php
+++ b/src/UKMNorge/DeltaBundle/Controller/InnslagController.php
@@ -127,7 +127,6 @@ class InnslagController extends Controller
         return $this->render('UKMDeltaBundle:Innslag:who.html.twig', $view_data);
     }
 
-
     /**
      * Oppretter innslaget, og legger til kontaktperson hvis dette skal gjøres
      * _@route: <ukmid/pamelding/$k_id-$pl_id/$type/opprett/$hvem/>
@@ -468,7 +467,12 @@ class InnslagController extends Controller
         // Sett alder
         $person->setFodselsdato(new DateTime(((int) date('Y') - $request->request->get('alder')) . '-01-01'));
 
-        $innslagService->leggTilPerson( $innslag, $person );
+        try {
+            $innslagService->leggTilPerson( $innslag, $person );            
+            $this->addFlash("success", "La til ".$person->getNavn());
+        } catch (Exception $e) {
+            $this->addFlash("danger", "Klarte ikke å legge til ".$person->getNavn()." i innslaget!");
+        }
 
         $view_data = [
             'k_id' => $k_id,
@@ -545,7 +549,12 @@ class InnslagController extends Controller
         $person->setRolle($request->request->get('instrument'));
 
         // Lagre
-        $this->get('ukm_api.person')->lagre($person, $innslag->getId());
+        try {
+            $this->get('ukm_api.person')->lagre($person, $innslag->getId());
+            $this->addFlash("success", "Lagret endringer");
+        } catch (Exception $e) {
+            $this->addFlash("danger", "Klarte ikke å lagre endringer på ".$person->getNavn()."!");
+        }
 
         return $this->redirectToRoute('ukm_delta_ukmid_pamelding_innslag_oversikt', $view_data);
     }
@@ -571,8 +580,13 @@ class InnslagController extends Controller
             'p_id' => $p_id
         ];
 
-        $this->get('ukm_api.innslag')->fjernPerson($b_id, $p_id);
-
+        try {
+            $this->get('ukm_api.innslag')->fjernPerson($b_id, $p_id);    
+            $this->addFlash("success", "Lagret endringer");
+        } catch (Exception $e) {
+            $this->addFlash("danger", "Klarte ikke å lagre endringer");
+        }
+        
         return $this->redirectToRoute('ukm_delta_ukmid_pamelding_innslag_oversikt', $route_data);
     }
 
@@ -621,9 +635,14 @@ class InnslagController extends Controller
         $request = Request::createFromGlobals();
         $innslagService = $this->get('ukm_api.innslag');
 
-        $innslag = $innslagService->hent($b_id);
-        $innslag->setTekniskeBehov($request->request->get('teknisk'));
-        $innslagService->lagre($innslag);
+        try {
+            $innslag = $innslagService->hent($b_id);
+            $innslag->setTekniskeBehov($request->request->get('teknisk'));
+            $innslagService->lagre($innslag);    
+            $this->addFlash("success", "Lagret tekniske behov");
+        } catch ( Exception $e ) {
+            $this->addFlash("danger", "Klarte ikke å lagre tekniske behov");
+        }
 
         return $this->redirectToRoute('ukm_delta_ukmid_pamelding_innslag_oversikt', $route_data);
     }
@@ -799,13 +818,17 @@ class InnslagController extends Controller
                 $tittel->setVarighet($request->request->get('lengde'));
                 break;
             default:
-                throw new Exception(
-                    'Beklager, prøvde å lagre en ukjent tittel-type'
-                );
+                $this->addFlash("danger", "Beklager, prøvde å lagre en ukjent tittel-type");
+                return $this->redirectToRoute('ukm_delta_ukmid_pamelding_innslag_oversikt', $view_data);
         }
 
-        $innslagService->lagreTitler($innslag, $tittel);
-        // Lagre tittel
+        try {
+            $innslagService->lagreTitler($innslag, $tittel);
+            $this->addFlash("success", "Lagret tittel-endringer!");
+        } catch ( Exception $e ) {
+            $this->addFlash("danger", "Klarte ikke å lagre tittel!");
+        }
+        
         return $this->redirectToRoute('ukm_delta_ukmid_pamelding_innslag_oversikt', $view_data);
     }
 
@@ -836,7 +859,13 @@ class InnslagController extends Controller
         $tittel = $innslag->getTitler()->get($t_id);
 
         // Fjern tittelen
-        $innslagService->fjernTittel($innslag, $tittel);
+        try {
+            $innslagService->fjernTittel($innslag, $tittel);    
+            $this->addFlash("success", "Fjernet tittel!");
+        } catch ( Exception $e ) {
+            $this->get('logger')->error("Klarte ikke å fjerne tittel ".$t_id." fra innslag ".$b_id.". Feilmelding: ".$e->getCode()." - ".$e->getMessage());
+            $this->addFlash("danger", "Klarte ikke å fjerne tittel");
+        }        
 
         return $this->redirectToRoute('ukm_delta_ukmid_pamelding_innslag_oversikt', $view_data);
     }

--- a/src/UKMNorge/DeltaBundle/Resources/views/Innslag/geo.html.twig
+++ b/src/UKMNorge/DeltaBundle/Resources/views/Innslag/geo.html.twig
@@ -101,6 +101,10 @@
                             {% endfor %}
                         </ul>
                     {% endfor %}
+                    {% if UKM_HOSTNAME == 'ukm.dev' %}
+                        Testkommune her
+                        
+                    {% endif %}
                 </div>
 
                 <p id="plNoneFound">

--- a/src/UKMNorge/DeltaBundle/Resources/views/Innslag/geo.html.twig
+++ b/src/UKMNorge/DeltaBundle/Resources/views/Innslag/geo.html.twig
@@ -101,10 +101,6 @@
                             {% endfor %}
                         </ul>
                     {% endfor %}
-                    {% if UKM_HOSTNAME == 'ukm.dev' %}
-                        Testkommune her
-                        
-                    {% endif %}
                 </div>
 
                 <p id="plNoneFound">

--- a/src/UKMNorge/DeltaBundle/Resources/views/Innslag/oversikt.html.twig
+++ b/src/UKMNorge/DeltaBundle/Resources/views/Innslag/oversikt.html.twig
@@ -12,6 +12,16 @@
 {% endblock %}
 
 {% block content %}
+	{% if app.session.flashBag.peekAll()|length > 0 %}
+		<div class="container">
+			<div class="row">
+				<div class="col-12">
+					{% embed "UKMDeltaDesignBundle:FlashBag:list.html.twig" %}{% endembed %}
+				</div>
+			</div>
+		</div>
+	{% endif %}
+
 	<div class="container">
 		<div class="row">
 			<div class="col-12">


### PR DESCRIPTION
@mariusmandal Nå kjører jeg kun try{} på selve lagre-funksjonen for å kødde med minst mulig - er det ønskelig at hele prosessen der foregår i try-catch? Slik at brukeren uansett får et fint flash-varsel i stedet for krasj-skjerm dersom noe er feil system-messig også?